### PR TITLE
Fixing small typo in manifest_validation

### DIFF
--- a/src/validation/manifest_validation.py
+++ b/src/validation/manifest_validation.py
@@ -26,7 +26,7 @@ def check_attributes(manifest, component, manifest_id):
                 pass
             else:
                 e = f'{req} is missing from DependsOn for manifest {manifest_id}'
-                print(f)
+                print(e)
                 continue
 
     else:


### PR DESCRIPTION
Fixing a small typo that was causing an error for the release scripts.
This issue was causing the google cloud run execution to fail producing shortlisted release tables in big query.